### PR TITLE
Extend and synchronize redcap backends

### DIFF
--- a/origins/backends/redcap_api.py
+++ b/origins/backends/redcap_api.py
@@ -50,11 +50,16 @@ class Client(base.Client):
                 'note': field['field_note'],
                 'type': field['field_type'],
                 'choices': field['select_choices_or_calculations'],
+                'display_logic': field['branching_logic'],
                 'validation_type': field['text_validation_type_or_show_slider_number'],  # noqa
                 'validation_min': field['text_validation_min'],
                 'validation_max': field['text_validation_max'],
                 'identifier': identifier,
                 'required': required,
+                'header': field['section_header'],
+                'alignment': field['custom_alignment'],
+                'survey_num': field['question_number'],
+                'matrix': field['matrix_group_name'],
             })
         return fields
 

--- a/origins/backends/redcap_csv.py
+++ b/origins/backends/redcap_csv.py
@@ -66,11 +66,16 @@ class Client(_file.Client):
                 'type': row['field_type'],
                 'note': row['field_note'],
                 'choices': row['choices'].replace(' | ', ' \\n '),
+                'display_logic': row['branching_logic'],
                 'validation_type': row['text_validation_type'],
                 'validation_min': row['text_validation_min'],
                 'validation_max': row['text_validation_max'],
                 'identifier': identifier,
                 'required': required,
+                'header': row['section_header'],
+                'alignment': row['custom_alignment'],
+                'survey_num': row['question_number'],
+                'matrix': row['matrix_group_name'],
             })
         return fields
 

--- a/origins/backends/redcap_mysql.py
+++ b/origins/backends/redcap_mysql.py
@@ -64,16 +64,19 @@ class Client(mysql.Client):
             SELECT
                 field_name,
                 element_label,
-                field_order,
                 element_type,
                 element_note,
                 element_enum,
-                field_units,
+                branching_logic,
                 element_validation_type,
                 element_validation_min,
                 element_validation_max,
+                field_phi,
                 field_req,
-                field_phi
+                element_preceding_header,
+                custom_alignment,
+                question_num,
+                grid_name
             FROM redcap_metadata JOIN redcap_projects
                 ON (redcap_metadata.project_id = redcap_projects.project_id)
             WHERE redcap_projects.project_name = %s
@@ -81,9 +84,10 @@ class Client(mysql.Client):
             ORDER BY field_order
         '''
 
-        keys = ('name', 'label', 'order', 'type', 'note', 'choices', 'units',
+        keys = ('name', 'label', 'type', 'note', 'choices', 'display_logic', 
                 'validation_type', 'validation_min', 'validation_max',
-                'required', 'identifier')
+                'identifier', 'required', 'header', 'alignment', 'survey_num', 
+                'matrix')
 
         fields = []
         for row in self.fetchall(query, [self.project_name, form_name]):


### PR DESCRIPTION
Remove order (because it is an internal value by which the fields should
be sorted, which they are, but it is not exposed through the api or csv
export) and units (because it is deprecated) from the redcap_mysql
backend and add display_logic, header, alignment, survey_num, and matrix
to all three redcap backends (api, csv, mysql).

Fixes #13 
