### PR TITLE
Introduce sections into redcap hierarchy

### DIFF
--- a/origins/backends/_redcap.py
+++ b/origins/backends/_redcap.py
@@ -1,5 +1,6 @@
 from __future__ import division, absolute_import
 from ..utils import cached_property
+from ..graph import Nodes
 from . import base
 
 
@@ -15,7 +16,24 @@ class Project(base.Node):
 
 class Form(base.Node):
     def sync(self):
-        self._contains(self.client.fields(self['name']), Field)
+        self._contains(self.client.sections(self['name']), Section)
+
+    @property
+    def sections(self):
+        return self._containers('section')
+
+    @property
+    def fields(self):
+        fields = []
+        for section in self.sections:
+            fields.extend(section.fields)
+        return Nodes(fields)
+
+
+class Section(base.Node):
+    def sync(self):
+        form_name = self.parent['name']
+        self._contains(self.client.fields(form_name, self['name']), Field)
 
     @property
     def fields(self):

--- a/origins/backends/redcap_api.py
+++ b/origins/backends/redcap_api.py
@@ -33,12 +33,30 @@ class Client(base.Client):
                 unique.add(name)
         return forms
 
-    def fields(self, form_name):
+    def sections(self, form_name):
+        sections = [{'name': 'default'}]
+        unique = set()
+        for field in self._project.metdata:
+            # Filter by form_name
+            if field['form_name'] != form_name:
+                continue
+            name = field['section_header']
+            if name not in unique:
+                sections.append({'name': name})
+                unique.add(name)
+        return sections
+
+    def fields(self, form_name, section_name):
         fields = []
+        current_section = 'default'
 
         for field in self._project.metadata:
             # Filter by form_name
             if field['form_name'] != form_name:
+                continue
+            # Filter by section_name
+            current_section = field['section_header'] or current_section
+            if current_section != section_name:
                 continue
 
             identifier = field['identifier'].lower() == 'y' and True or False

--- a/origins/backends/redcap_csv.py
+++ b/origins/backends/redcap_csv.py
@@ -48,13 +48,32 @@ class Client(_file.Client):
                 unique.add(form_name)
         return forms
 
-    def fields(self, form_name):
+    def sections(self, form_name):
+        reader = self.reader
+        sections = [{'name': 'default'}]
+        unique = set()
+        for row in reader:
+            # Filter by form_name
+            if row['form_name'] != form_name:
+                continue
+            name = row['section_header']
+            if name not in unique:
+                sections.append({'name': name})
+                unique.add(name)
+        return sections
+
+    def fields(self, form_name, section_name):
         reader = self.reader
         fields = []
+        current_section = 'default'
 
         for row in reader:
             # Filter by form_name
             if row['form_name'] != form_name:
+                continue
+            # Filter by section_name
+            current_section = row['section_header'] or current_section
+            if current_section != section_name:
                 continue
 
             identifier = row['identifier'].lower() == 'y' and True or False


### PR DESCRIPTION
Modify the Form node class in _redcap so that form.fields will return
all fields in all sections of the form and form.sections will return all
sections. Create the Section node class in _redcap so that
section.fields will return all fields in the section. Modify the sync
method on Form to call client.sections and create the sync method on
Section to call client.fields, passing the parent form name in addition
to the section name.

Modify all three backend Client classes by adding a sections method that
returns all unique sections found on a form, and always returns at least
a section named 'default' (since sections are optional in redcap).
Modify all three backend Client classes' fields method to take a section
name in addition to the form name and filter the results to only include
fields in that section (when 'default' is passed as the section name,
all fields before the first defined section are returned).

Implements the sections idea suggested by @bruth in #13
