### PR TITLE
Clean up the redcap section class addition

### DIFF
--- a/origins/backends/redcap_api.py
+++ b/origins/backends/redcap_api.py
@@ -36,9 +36,9 @@ class Client(base.Client):
     def sections(self, form_name):
         sections = [{'name': 'default'}]
         unique = set()
-        for field in self._project.metdata:
+        for field in self._project.metadata:
             # Filter by form_name
-            if field['form_name'] != form_name:
+            if field['form_name'] != form_name or not field['section_header']:
                 continue
             name = field['section_header']
             if name not in unique:

--- a/origins/backends/redcap_csv.py
+++ b/origins/backends/redcap_csv.py
@@ -54,7 +54,7 @@ class Client(_file.Client):
         unique = set()
         for row in reader:
             # Filter by form_name
-            if row['form_name'] != form_name:
+            if row['form_name'] != form_name or not row['section_header']:
                 continue
             name = row['section_header']
             if name not in unique:


### PR DESCRIPTION
Fix a typo in redcap_api ('metdata' -> 'metadata'). Keep redcap_api and
redcap_csv clients from generating a 'None' section on every form by
ignoring rows/fields where section_header is not truthy.

Basically a hotfix, based on my own testing.
