### PR TITLE
Implement backend data dictionary-style delimited files

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ One or more **options** can be passed to the backend. **Hierarchy** lists the pa
 
 #### Files
 
-- `delimited` - General backed for acessing fixed width delimited files.
+- `delimited` - General backend for accessing fixed width delimited files.
     - [Example](http://nbviewer.ipython.org/urls/raw.github.com/cbmi/origins/master/notebooks/Delimited%2520Example.ipynb)
 - `csv` - Alias for the `,` delimiter
 - `tab` - Alias for the `\t` delimiter
+- `datadict` General backend for data dictionary-style delimited files.
+    - [Example](http://nbviewer.ipython.org/urls/raw.github.com/cbmi/origins/master/notebooks/DataDict%2520Example.ipynb)
 
 **Options**
 
@@ -143,7 +145,7 @@ One or more **options** can be passed to the backend. **Hierarchy** lists the pa
 **Hierarchy**
 
 - `file`
-- `columns`
+- `columns` (delimited) | `fields` (datadict)
 
 #### Excel
 

--- a/notebooks/DataDict Example.ipynb
+++ b/notebooks/DataDict Example.ipynb
@@ -1,0 +1,151 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:e7cfdee4ad597a8446f75521de4a1bf876399099b6a7b8f8717209a04101529e"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import origins"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "datadict = origins.connect('datadict', path='../tests/data/chinook_tracks_datadict.csv')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "datadict"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 3,
+       "text": [
+        "File('chinook_tracks_datadict.csv')"
+       ]
+      }
+     ],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "datadict.props"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 4,
+       "text": [
+        "{'delimiter': ',',\n",
+        " 'name': 'chinook_tracks_datadict.csv',\n",
+        " 'path': '/Users/ruthb/Code/cbmi/origins/tests/data/chinook_tracks_datadict.csv'}"
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "datadict.fields"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 5,
+       "text": [
+        "(Field('TrackId'),\n",
+        " Field('Name'),\n",
+        " Field('AlbumId'),\n",
+        " Field('MediaTypeId'),\n",
+        " Field('GenreId'),\n",
+        " Field('Composer'),\n",
+        " Field('Milliseconds'),\n",
+        " Field('Bytes'),\n",
+        " Field('UnitPrice'))"
+       ]
+      }
+     ],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "datadict.fields['Name']"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 6,
+       "text": [
+        "Field('Name')"
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "datadict.fields['Name'].props"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 7,
+       "text": [
+        "{'index': 1,\n",
+        " u'name': u'Name',\n",
+        " u'nullable': u'0',\n",
+        " u'primary_key': u'0',\n",
+        " u'type': u'NVARCHAR(200)'}"
+       ]
+      }
+     ],
+     "prompt_number": 7
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/origins/api.py
+++ b/origins/api.py
@@ -38,6 +38,7 @@ BACKENDS = {
     'noop': 'origins.backends.noop',
     'solvebio': 'origins.backends.solvebio',
     'harvest': 'origins.backends.harvest',
+    'datadict': 'origins.backends.datadict',
 }
 
 BACKEND_ALIASES = {

--- a/origins/backends/datadict.py
+++ b/origins/backends/datadict.py
@@ -1,0 +1,37 @@
+from __future__ import division, absolute_import
+
+from . import _file, base, delimited
+
+
+class Client(delimited.Client):
+    def fields(self):
+        fields = []
+
+        for i, row in enumerate(self.reader):
+            field = dict(zip(self.header, row))
+            field['index'] = i
+            fields.append(field)
+
+        return fields
+
+
+class File(_file.File):
+    @property
+    def name_attribute(self):
+        return self.client.header[0]
+
+    def sync(self):
+        super(File, self).sync()
+        self.define(self.client.fields(), Field)
+
+    @property
+    def fields(self):
+        return self.definitions('field', sort='index')
+
+
+class Field(base.Node):
+    pass
+
+
+# Export for API
+Origin = File

--- a/tests/backends/datadict.py
+++ b/tests/backends/datadict.py
@@ -1,0 +1,62 @@
+from __future__ import unicode_literals, absolute_import
+
+import os
+import origins
+from .base import BackendTestCase, TEST_DATA_DIR
+
+
+class DataDictClientTestCase(BackendTestCase):
+    backend_path = 'origins.backends.datadict'
+
+    def setUp(self):
+        self.load_backend()
+        path = os.path.join(TEST_DATA_DIR, 'chinook_tracks_datadict.csv')
+        self.client = self.backend.Client(path)
+
+    def test_reader(self):
+        row = next(self.client.reader)
+        # Ensure the header is skipped
+        self.assertEqual(row[0], 'TrackId')
+
+    def test_setup(self):
+        self.assertTrue(self.client.has_header)
+        self.assertEqual(self.client.delimiter, ',')
+
+    def test_properties(self):
+        self.assertGreater(self.client.file_line_count(), 0)
+
+    def test_file(self):
+        self.assertTrue(self.client.file())
+
+    def test_fields(self):
+        fields = self.client.fields()
+        self.assertEqual(len(fields), 9)
+        self.assertTrue('name' in fields[0])
+
+
+class DataDictApiTestCase(BackendTestCase):
+    backend_path = 'origins.backends.datadict'
+
+    def setUp(self):
+        self.path = os.path.join(TEST_DATA_DIR, 'chinook_tracks_datadict.csv')
+        self.f = origins.connect('datadict', path=self.path)
+
+    def test_file(self):
+        self.assertEqual(self.f.label, 'chinook_tracks_datadict.csv')
+        self.assertEqual(self.f.name, 'chinook_tracks_datadict.csv')
+        self.assertEqual(self.f.path, 'chinook_tracks_datadict.csv')
+        self.assertEqual(self.f.uri, 'datadict:///chinook_tracks_datadict.csv')
+        self.assertEqual(self.f.relpath, [])
+        self.assertTrue(self.f.isroot)
+        self.assertFalse(self.f.isleaf)
+        self.assertTrue('uri' in self.f.serialize())
+
+    def test_field(self):
+        field = self.f.fields['TrackId']
+
+        self.assertEqual(field.label, 'TrackId')
+        self.assertEqual(field.name, 'TrackId')
+        self.assertEqual(field.path, 'chinook_tracks_datadict.csv/TrackId')
+        self.assertEqual(len(field.relpath), 1)
+        self.assertFalse(field.isroot)
+        self.assertTrue(field.isleaf)

--- a/tests/data/chinook_tracks_datadict.csv
+++ b/tests/data/chinook_tracks_datadict.csv
@@ -1,0 +1,10 @@
+name,type,nullable,primary_key
+"TrackId","INTEGER",0,1
+"Name","NVARCHAR(200)",0,0
+"AlbumId","INTEGER",1,0
+"MediaTypeId","INTEGER",0,0
+"GenreId",INTEGER",1,0
+"Composer","NVARCHAR(220)",1,0
+"Milliseconds","INTEGER",0,0
+"Bytes","INTEGER",0,0
+"UnitPrice","NUMERIC(10,2)",0,0


### PR DESCRIPTION
The header of the file represents the attributes of the fields, while the
rows contain the fields themselves. The first column is assumed to be the
field ID or name.

Fix #56

Signed-off-by: Byron Ruth b@devel.io
