### PR TITLE
Manually inspect test result for failures or errors

### DIFF
--- a/test_suite.py
+++ b/test_suite.py
@@ -6,8 +6,13 @@ if __name__ == '__main__':
 
     loader = unittest.TestLoader()
     runner = unittest.runner.TextTestRunner()
+
     if sys.argv[1:]:
         tests = loader.loadTestsFromNames(sys.argv[1:])
     else:
         tests = loader.discover('tests', '*.py')
-    runner.run(tests)
+
+    result = runner.run(tests)
+
+    if result.errors or result.failures:
+        sys.exit(1)


### PR DESCRIPTION
Manually loading and running tests requires sys.exit needs to be
called explicitly.

Fix #62

Signed-off-by: Byron Ruth b@devel.io
