### PR TITLE
Rename segment ID to Transaction, add UUID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install:
 	go get github.com/spf13/viper
 	go get github.com/spf13/cobra
 	go get github.com/psilva261/timsort
+	go get github.com/satori/go.uuid
 
 test-install: install
 	go get golang.org/x/tools/cmd/cover

--- a/pb/protobuf.pb.go
+++ b/pb/protobuf.pb.go
@@ -62,19 +62,19 @@ func (m *Transaction) GetEndTime() int64 {
 // Upon a successful transaction, the head is updated to point to the most
 // segment.
 type Log struct {
-	Head             *uint64 `protobuf:"varint,1,opt" json:"Head,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Head             []byte `protobuf:"bytes,1,opt" json:"Head,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
 }
 
 func (m *Log) Reset()         { *m = Log{} }
 func (m *Log) String() string { return proto.CompactTextString(m) }
 func (*Log) ProtoMessage()    {}
 
-func (m *Log) GetHead() uint64 {
-	if m != nil && m.Head != nil {
-		return *m.Head
+func (m *Log) GetHead() []byte {
+	if m != nil {
+		return m.Head
 	}
-	return 0
+	return nil
 }
 
 // A segment behaves as a node in a linked list in the scope of a domain. It
@@ -82,13 +82,14 @@ func (m *Log) GetHead() uint64 {
 // To access the facts, the segment key is combined with a block index, e.g
 // segment.1.0 which translates to "segment 1 block 0".
 type Segment struct {
-	ID               *uint64 `protobuf:"varint,1,req" json:"ID,omitempty"`
-	Time             *int64  `protobuf:"varint,2,req" json:"Time,omitempty"`
-	Blocks           *int32  `protobuf:"varint,3,req" json:"Blocks,omitempty"`
-	Count            *int32  `protobuf:"varint,4,req" json:"Count,omitempty"`
-	Bytes            *int32  `protobuf:"varint,5,req" json:"Bytes,omitempty"`
-	Next             *uint64 `protobuf:"varint,6,opt" json:"Next,omitempty"`
-	Base             *uint64 `protobuf:"varint,7,opt" json:"Base,omitempty"`
+	UUID             []byte  `protobuf:"bytes,1,req" json:"UUID,omitempty"`
+	Transaction      *uint64 `protobuf:"varint,2,req" json:"Transaction,omitempty"`
+	Time             *int64  `protobuf:"varint,3,req" json:"Time,omitempty"`
+	Blocks           *int32  `protobuf:"varint,4,req" json:"Blocks,omitempty"`
+	Count            *int32  `protobuf:"varint,5,req" json:"Count,omitempty"`
+	Bytes            *int32  `protobuf:"varint,6,req" json:"Bytes,omitempty"`
+	Next             []byte  `protobuf:"bytes,7,opt" json:"Next,omitempty"`
+	Base             []byte  `protobuf:"bytes,8,opt" json:"Base,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -96,9 +97,16 @@ func (m *Segment) Reset()         { *m = Segment{} }
 func (m *Segment) String() string { return proto.CompactTextString(m) }
 func (*Segment) ProtoMessage()    {}
 
-func (m *Segment) GetID() uint64 {
-	if m != nil && m.ID != nil {
-		return *m.ID
+func (m *Segment) GetUUID() []byte {
+	if m != nil {
+		return m.UUID
+	}
+	return nil
+}
+
+func (m *Segment) GetTransaction() uint64 {
+	if m != nil && m.Transaction != nil {
+		return *m.Transaction
 	}
 	return 0
 }
@@ -131,18 +139,18 @@ func (m *Segment) GetBytes() int32 {
 	return 0
 }
 
-func (m *Segment) GetNext() uint64 {
-	if m != nil && m.Next != nil {
-		return *m.Next
+func (m *Segment) GetNext() []byte {
+	if m != nil {
+		return m.Next
 	}
-	return 0
+	return nil
 }
 
-func (m *Segment) GetBase() uint64 {
-	if m != nil && m.Base != nil {
-		return *m.Base
+func (m *Segment) GetBase() []byte {
+	if m != nil {
+		return m.Base
 	}
-	return 0
+	return nil
 }
 
 // Facts do not contain omit the domain and transaction ID since this info

--- a/pb/protobuf.proto
+++ b/pb/protobuf.proto
@@ -13,7 +13,7 @@ message Transaction {
 // Upon a successful transaction, the head is updated to point to the most
 // segment.
 message Log {
-    optional uint64 Head = 1;
+    optional bytes Head = 1;
 }
 
 // A segment behaves as a node in a linked list in the scope of a domain. It
@@ -21,13 +21,14 @@ message Log {
 // To access the facts, the segment key is combined with a block index, e.g
 // segment.1.0 which translates to "segment 1 block 0".
 message Segment {
-    required uint64 ID = 1;
-    required int64 Time = 2;
-    required int32 Blocks = 3;
-    required int32 Count = 4;
-    required int32 Bytes = 5;
-    optional uint64 Next = 6;
-    optional uint64 Base = 7;
+    required bytes UUID = 1;
+    required uint64 Transaction = 2;
+    required int64 Time = 3;
+    required int32 Blocks = 4;
+    required int32 Count = 5;
+    required int32 Bytes = 6;
+    optional bytes Next = 7;
+    optional bytes Base = 8;
 }
 
 // Facts do not contain omit the domain and transaction ID since this info

--- a/transactor/log_test.go
+++ b/transactor/log_test.go
@@ -44,7 +44,7 @@ func TestSegment(t *testing.T) {
 
 	// Confirm bolt is doing its job..
 	for i := 0; i < segment.Blocks; i++ {
-		k = fmt.Sprintf(BlockKey, segment.ID, i)
+		k = fmt.Sprintf(BlockKey, segment.UUID, i)
 		b, err = engine.Get("test", k)
 
 		if b == nil {
@@ -58,7 +58,7 @@ func TestSegment(t *testing.T) {
 
 	// Confirm aborted entries have been deleted
 	for i := 0; i < segment.Blocks; i++ {
-		k = fmt.Sprintf(BlockKey, segment.ID, i)
+		k = fmt.Sprintf(BlockKey, segment.UUID, i)
 		b, err = engine.Get("test", k)
 
 		if b != nil {

--- a/transactor/transact_test.go
+++ b/transactor/transact_test.go
@@ -11,13 +11,7 @@ import (
 )
 
 func checkCommitted(t *testing.T, engine storage.Engine, domain string, id uint64) {
-	if b, err := engine.Get(domain, fmt.Sprintf(SegmentKey, id)); err != nil {
-		t.Errorf("transact: %s", err)
-	} else if b == nil {
-		t.Errorf("transact: expected segment %d to exist", id)
-	}
-
-	b, err := engine.Get(domain, LogKey)
+	b, err := engine.Get(domain, fmt.Sprintf(LogKey, commitLogName))
 
 	log := Log{}
 
@@ -25,8 +19,16 @@ func checkCommitted(t *testing.T, engine storage.Engine, domain string, id uint6
 		t.Fatal(err)
 	}
 
-	if log.Head != id {
-		t.Errorf("expected %d, got %d", id, log.Head)
+	b, err = engine.Get(domain, fmt.Sprintf(SegmentKey, log.Head))
+
+	seg := Segment{}
+
+	if err = unmarshalSegment(b, &seg); err != nil {
+		t.Fatal(err)
+	}
+
+	if seg.Transaction != id {
+		t.Errorf("expected %d, got %d", id, seg.Transaction)
 	}
 }
 

--- a/view/unmarshal.go
+++ b/view/unmarshal.go
@@ -8,6 +8,7 @@ import (
 	"github.com/chop-dbhi/origins/chrono"
 	"github.com/chop-dbhi/origins/pb"
 	"github.com/golang/protobuf/proto"
+	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,6 +23,20 @@ const (
 	factPrefixSize = 2
 )
 
+func decodeUUID(b []byte) *uuid.UUID {
+	if b == nil {
+		return nil
+	}
+
+	u, err := uuid.FromBytes(b)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &u
+}
+
 func unmarshalSegment(b []byte, s *segment) error {
 	m := pb.Segment{}
 
@@ -29,13 +44,14 @@ func unmarshalSegment(b []byte, s *segment) error {
 		return err
 	}
 
-	s.ID = m.GetID()
+	s.UUID = decodeUUID(m.GetUUID())
+	s.Transaction = m.GetTransaction()
 	s.Time = chrono.MicroTime(m.GetTime())
 	s.Blocks = int(m.GetBlocks())
 	s.Count = int(m.GetCount())
 	s.Bytes = int(m.GetBytes())
-	s.Next = m.GetNext()
-	s.Base = m.GetBase()
+	s.Next = decodeUUID(m.GetNext())
+	s.Base = decodeUUID(m.GetBase())
 
 	return nil
 }
@@ -47,7 +63,7 @@ func unmarshalLog(b []byte, l *Log) error {
 		return err
 	}
 
-	l.head = m.GetHead()
+	l.head = decodeUUID(m.GetHead())
 
 	return nil
 }


### PR DESCRIPTION
This removes the implicit mapping from transaction to segment since
multiple segments could be created within a transaction. Each segment
is now uniquely addressable.

Fix #130