### PR TITLE
Log de-duplication and merging logs from multiple domains.

### DIFF
--- a/testutil/test.go
+++ b/testutil/test.go
@@ -19,11 +19,38 @@ func randomString(n int) string {
 	return string(b)
 }
 
-type GeneratorFunc func(domain string, tx uint64) *origins.Fact
+type EAVDictionary struct {
+	entity    []string
+	attribute []string
+	value     []string
+}
+
+// NewEAVDictionary generates a dictionary of E, A, V values.
+func NewEAVDictionary(eLen, aLen, vLen int) *EAVDictionary {
+	dict := EAVDictionary{
+		entity:    make([]string, eLen),
+		attribute: make([]string, aLen),
+		value:     make([]string, vLen),
+	}
+
+	for i := range dict.entity {
+		dict.entity[i] = randomString(16)
+	}
+	for i := range dict.attribute {
+		dict.attribute[i] = randomString(16)
+	}
+	for i := range dict.value {
+		dict.value[i] = randomString(32)
+	}
+
+	return &dict
+}
+
+type GeneratorFunc func(domains []string, tx uint64) *origins.Fact
 
 type FactGen struct {
 	generator GeneratorFunc
-	domain    string
+	domains   []string
 	tx        uint64
 	count     int
 	size      int
@@ -36,7 +63,7 @@ func (r *FactGen) Next() *origins.Fact {
 
 	r.count += 1
 
-	return r.generator(r.domain, r.tx)
+	return r.generator(r.domains, r.tx)
 }
 
 func (r *FactGen) Err() error {
@@ -71,20 +98,45 @@ func (r *FactGen) Subscribe(closer chan struct{}) (chan *origins.Fact, chan erro
 	return fch, errch
 }
 
-func NewGenerator(domain string, tx uint64, size int, gen GeneratorFunc) *FactGen {
+func NewGenerator(domains []string, tx uint64, size int, gen GeneratorFunc) *FactGen {
 	return &FactGen{
 		generator: gen,
-		domain:    domain,
+		domains:   domains,
 		tx:        tx,
 		size:      size,
 	}
 }
 
-// RandFact generates a fact with a random entity, attribute, and value.
+// RandFactMultiDomain generates a fact with a random entity, attribute, and value;
+// the fact will belong to a domain randomly chosen from the specified list.
+func RandFactMultiDomain(domains []string, tx uint64) *origins.Fact {
+	d := domains[rand.Intn(len(domains))]
+	return RandFact(d, tx)
+}
+
+// RandFactSingleDomain is a wrapper to RandFact that's needed only to
+// get the single domain out of the domains array
+func RandFactSingleDomain(domains []string, tx uint64) *origins.Fact {
+	return RandFact(domains[0], tx)
+}
+
+// RandFact generates a fact with a random entity, attribute, and value
+// for a given domain
 func RandFact(domain string, tx uint64) *origins.Fact {
-	e := &origins.Ident{domain, randomString(16)}
-	a := &origins.Ident{domain, randomString(16)}
-	v := &origins.Ident{domain, randomString(32)}
+	e := &origins.Ident{
+		Domain: domain,
+		Name:   randomString(16),
+	}
+
+	a := &origins.Ident{
+		Domain: domain,
+		Name:   randomString(16),
+	}
+
+	v := &origins.Ident{
+		Domain: domain,
+		Name:   randomString(32),
+	}
 
 	return &origins.Fact{
 		Operation:   origins.Assertion,
@@ -96,9 +148,56 @@ func RandFact(domain string, tx uint64) *origins.Fact {
 	}
 }
 
+// RandDictionaryFact returns a GeneratorFunc for generating facts from a given dictionary of values
+// for a single domain
+func RandDictionaryFact(dictionary *EAVDictionary) GeneratorFunc {
+	return func(domains []string, tx uint64) *origins.Fact {
+		domain := domains[0]
+
+		e := &origins.Ident{
+			Domain: domain,
+			Name:   dictionary.entity[rand.Intn(len(dictionary.entity))],
+		}
+
+		a := &origins.Ident{
+			Domain: domain,
+			Name:   dictionary.attribute[rand.Intn(len(dictionary.attribute))],
+		}
+
+		v := &origins.Ident{
+			Domain: domain,
+			Name:   dictionary.value[rand.Intn(len(dictionary.value))],
+		}
+
+		return &origins.Fact{
+			Operation:   origins.Assertion,
+			Domain:      domain,
+			Entity:      e,
+			Attribute:   a,
+			Value:       v,
+			Transaction: tx,
+		}
+	}
+}
+
 // NewRandGenerator returns a fact generator using the default RandFact
 // generator function.
 func NewRandGenerator(domain string, tx uint64, size int) *FactGen {
 	rand.Seed(time.Now().UnixNano())
-	return NewGenerator(domain, tx, size, RandFact)
+	d := []string{domain}
+	return NewGenerator(d, tx, size, RandFactSingleDomain)
+}
+
+// NewDictionaryBasedGenerator returns a fact generator using the default
+// RandDictionaryFact generator function.
+func NewDictionaryBasedGenerator(dictionary *EAVDictionary, domain string, tx uint64, size int) *FactGen {
+	rand.Seed(time.Now().UnixNano())
+	d := []string{domain}
+	return NewGenerator(d, tx, size, RandDictionaryFact(dictionary))
+}
+
+// NewMultiDomainGenerator returns a fact generator for multiple domains
+func NewMultidomainGenerator(domains []string, tx uint64, size int) *FactGen {
+	rand.Seed(time.Now().UnixNano())
+	return NewGenerator(domains, tx, size, RandFactMultiDomain)
 }

--- a/view/log_test.go
+++ b/view/log_test.go
@@ -1,6 +1,7 @@
 package view
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,6 +28,44 @@ func randStorage(domain string, n, m int) storage.Engine {
 	return engine
 }
 
+// Initializes an in-memory store and generates n transactions each with m
+// randomly generated facts that belong to one of the specified domains.
+func randMultidomainStorage(domains []string, n, m int) storage.Engine {
+	engine, _ := origins.Init("memory", nil)
+
+	for i := 0; i < m; i++ {
+		tx, _ := transactor.New(engine, transactor.DefaultOptions)
+
+		gen := testutil.NewMultidomainGenerator(domains, tx.ID, n)
+
+		tx.AppendIter(gen)
+		tx.Commit()
+	}
+
+	return engine
+}
+
+// Initializes an in-memory store and generates n transactions each with m
+// facts randomly generated from the same dictionary of possible E, A, V values.
+// Varying the size of the dictionary relative to the size of the store
+// allows to guarantee repeating facts.
+func randStorageWRepeats(domain string, n, m, eLen, aLen, vLen int) storage.Engine {
+	engine, _ := origins.Init("memory", nil)
+
+	dictionary := testutil.NewEAVDictionary(eLen, aLen, vLen)
+
+	for i := 0; i < m; i++ {
+		tx, _ := transactor.New(engine, transactor.DefaultOptions)
+
+		gen := testutil.NewDictionaryBasedGenerator(dictionary, domain, tx.ID, n)
+
+		tx.AppendIter(gen)
+		tx.Commit()
+	}
+
+	return engine
+}
+
 func TestLogIter(t *testing.T) {
 	domain := "test"
 
@@ -45,12 +84,79 @@ func TestLogIter(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	num, err := testNext(log.Now())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if num != n*m {
+		t.Errorf("expected %d facts, got %d", n*m, num)
+	}
+}
+
+func TestMultiDomainLogIter(t *testing.T) {
+	domains := []string{"test", "another_test"}
+
+	// Number of transactions
+	n := 100
+
+	// Number of facts per transaction
+	m := 100
+
+	engine := randMultidomainStorage(domains, n, m)
+
+	// Open and merge the commit logs.
+
+	log0, err := OpenLog(engine, domains[0], "commit")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log1, err := OpenLog(engine, domains[1], "commit")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	mergedStreams := Merge(log0.Asof(now), log1.Asof(now))
+
+	if err = mergedStreams.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	i := 0
+	var prevTrnId uint64 = 1<<64 - 1
+	for {
+		f := mergedStreams.Next()
+
+		if err = mergedStreams.Err(); err != nil {
+			t.Fatal(err)
+		}
+
+		if f == nil {
+			break
+		} else {
+			if prevTrnId < f.Transaction {
+				t.Errorf("Transactions are ordered incorrectly")
+			}
+			i++
+		}
+	}
+
+	if i != n*m {
+		t.Errorf("expected %d facts, got %d", n*m, i)
+	}
+}
+
+// Test the Next() method for the given iterator.
+// Return the number of elements encountered.
+func testNext(iter origins.Iterator) (int, error) {
 	var (
 		i int
 		f *origins.Fact
 	)
-
-	iter := log.Now()
 
 	for {
 		if f = iter.Next(); f == nil {
@@ -60,13 +166,145 @@ func TestLogIter(t *testing.T) {
 		i++
 	}
 
-	if iter.Err() != nil {
-		t.Fatal(iter.Err())
+	if err := iter.Err(); err != nil {
+		return 0, err
 	}
 
-	if i != n*m {
-		t.Errorf("expected %d facts, got %d", n*m, i)
+	return i, nil
+}
+
+func TestLogExcludeDuplicates(t *testing.T) {
+	domain := "test"
+
+	// number of transactions
+	n := 100
+
+	// number of facts per transaction
+	m := 100
+
+	eLen, aLen, vLen := 2, 3, 4
+
+	engine := randStorageWRepeats(domain, n, m, eLen, aLen, vLen)
+
+	// Open the commit log.
+	log, err := OpenLog(engine, domain, "commit")
+
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	// first check the total number of facts
+	num, err := testNext(log.Now())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if num != n*m {
+		t.Errorf("expected %d total facts, got %d", n*m, num)
+	}
+
+	// Now check that Next() works on the deduplicated stream,
+	// and verify the number of unique facts.
+
+	iter := Deduplicate(log.Now())
+	if err := iter.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	num, err = testNext(iter)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// With the dictionary size being very small (e.g. 24) compared to the number of generated facts (e.g. 10,000),
+	// the probability that any of the possible facts didn't get generated is negligible
+	if num != eLen*aLen*vLen {
+		t.Errorf("expected %d unique facts, got %d", eLen*aLen*vLen, num)
+	}
+}
+
+func benchmarkDeduplication(b *testing.B, numTrn, factsPerTrn, eLen, aLen, vLen int) {
+	domain := "test"
+
+	engine := randStorageWRepeats(domain, numTrn, factsPerTrn, eLen, aLen, vLen)
+	log, err := OpenLog(engine, domain, "commit")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+
+		now := log.Now()
+
+		iter := Deduplicate(now)
+		if err = iter.Err(); err != nil {
+			b.Fatal(err)
+		}
+
+		// The Deduplicate() operation is lazy, and most of the actual work happens during Next(),
+		// so to evaluate the true cost of deduplication we need to time how long it takes to step
+		// through the resulting iterator.
+		_, err = testNext(iter)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDeduplication(b *testing.B) {
+	benchmarkDeduplication(b, 100, 100, 3, 4, 5)
+}
+
+func benchmarkDomainMerge(b *testing.B, numTrn, factsPerTrn, numDomains int) {
+	domains := make([]string, numDomains)
+	var err error
+	iters := make([]origins.Iterator, len(domains))
+	logs := make([]*Log, len(domains))
+
+	for j := 0; j < numDomains; j++ {
+		domains[j] = "domain_" + strconv.Itoa(j+1)
+	}
+
+	engine := randMultidomainStorage(domains, numTrn, factsPerTrn)
+
+	for j := 0; j < len(domains); j++ {
+		logs[j], err = OpenLog(engine, domains[j], "commit")
+
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	now := time.Now()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < len(domains); j++ {
+			iters[j] = logs[j].Asof(now)
+		}
+
+		iter := Merge(iters...)
+
+		if err := iter.Err(); err != nil {
+			b.Fatal(err)
+		}
+
+		// The Merge() operation is lazy, and most of the actual work happens during Next(),
+		// so to evaluate the true cost of merging we need to time how long it takes to step
+		// through the resulting iterator.
+		_, err = testNext(iter)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDomainMerge(b *testing.B) {
+	benchmarkDomainMerge(b, 100, 100, 3)
 }
 
 func TestLogReader(t *testing.T) {


### PR DESCRIPTION
Deduplicate() method takes an Iterator and returns an Iterator with
duplicate facts removed from the stream.

Merge() method takes multiple Iterators, combines their fact streams
into one time-ordered stream, and and returns an Iterator for the
resulting stream.