### PR TITLE
Refactor block encoding/decoding

### DIFF
--- a/dal/dal_test.go
+++ b/dal/dal_test.go
@@ -1,0 +1,369 @@
+package dal
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chop-dbhi/origins"
+	"github.com/chop-dbhi/origins/chrono"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogMethods(t *testing.T) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+
+	l := Log{
+		Name:   "commit",
+		Domain: "testing",
+		Head:   &id,
+	}
+
+	_, err := SetLog(engine, "testing", &l)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	l2, err := GetLog(engine, "testing", "commit")
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, l.Name, l2.Name)
+	assert.Equal(t, l.Domain, l2.Domain)
+	assert.Equal(t, *l.Head, *l2.Head)
+}
+
+func TestSegmentMethods(t *testing.T) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+	next := uuid.NewV4()
+
+	now := chrono.Norm(time.Now().UTC())
+
+	s := Segment{
+		UUID:        &id,
+		Transaction: 10,
+		Domain:      "testing",
+		Time:        now,
+		Blocks:      5,
+		Count:       4800,
+		Bytes:       460800,
+		Next:        &next,
+		Base:        &next,
+	}
+
+	_, err := SetSegment(engine, "testing", &s)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	s2, err := GetSegment(engine, "testing", &id)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, s.Transaction, s2.Transaction)
+	assert.Equal(t, *s.Next, *s2.Next)
+}
+
+func TestTransactionMethods(t *testing.T) {
+	engine, _ := origins.Init("memory", nil)
+
+	start := time.Now().UTC()
+	end := start.Add(2 * time.Second)
+
+	tx := &Transaction{
+		ID:        1,
+		StartTime: chrono.Norm(start),
+		EndTime:   chrono.Norm(end),
+		Error:     errors.New("transaction error"),
+	}
+
+	_, err := SetTransaction(engine, tx)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	tx2, err := GetTransaction(engine, 1)
+
+	assert.Equal(t, tx.StartTime, tx2.StartTime)
+	assert.Equal(t, tx.EndTime, tx2.EndTime)
+	assert.Equal(t, tx.Error, tx2.Error)
+}
+
+func TestBlockMethods(t *testing.T) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+	idx := 0
+
+	f := &origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < 1000; i++ {
+		encoder.Write(f)
+	}
+
+	_, err := SetBlock(engine, "testing", &id, idx, encoder.Bytes())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = GetBlock(engine, "testing", &id, idx)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkSetLog(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+
+	l := &Log{
+		Name: "commit",
+		Head: &id,
+	}
+
+	for i := 0; i < b.N; i++ {
+		SetLog(engine, "testing", l)
+	}
+}
+
+func BenchmarkGetLog(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+
+	l := &Log{
+		Name: "commit",
+		Head: &id,
+	}
+
+	SetLog(engine, "testing", l)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		GetLog(engine, "testing", "commit")
+	}
+}
+
+func BenchmarkSetSegment(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+	next := uuid.NewV4()
+
+	now := chrono.Norm(time.Now().UTC())
+
+	s := &Segment{
+		UUID:        &id,
+		Transaction: 10,
+		Domain:      "testing",
+		Time:        now,
+		Blocks:      5,
+		Count:       4800,
+		Bytes:       460800,
+		Next:        &next,
+		Base:        &next,
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		SetSegment(engine, "testing", s)
+	}
+}
+
+func BenchmarkGetSegment(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+	next := uuid.NewV4()
+
+	now := chrono.Norm(time.Now().UTC())
+
+	s := &Segment{
+		UUID:        &id,
+		Transaction: 10,
+		Domain:      "testing",
+		Time:        now,
+		Blocks:      5,
+		Count:       4800,
+		Bytes:       460800,
+		Next:        &next,
+		Base:        &next,
+	}
+
+	SetSegment(engine, "testing", s)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		GetSegment(engine, "testing", &id)
+	}
+}
+
+func BenchmarkSetTransaction(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	start := time.Now().UTC()
+	end := start.Add(2 * time.Second)
+
+	tx := &Transaction{
+		ID:        1,
+		StartTime: chrono.Norm(start),
+		EndTime:   chrono.Norm(end),
+		Error:     errors.New("transaction error"),
+	}
+
+	for i := 0; i < b.N; i++ {
+		SetTransaction(engine, tx)
+	}
+}
+
+func BenchmarkGetTransaction(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	start := time.Now().UTC()
+	end := start.Add(2 * time.Second)
+
+	tx := &Transaction{
+		ID:        1,
+		StartTime: chrono.Norm(start),
+		EndTime:   chrono.Norm(end),
+		Error:     errors.New("transaction error"),
+	}
+
+	SetTransaction(engine, tx)
+
+	for i := 0; i < b.N; i++ {
+		GetTransaction(engine, tx.ID)
+	}
+}
+
+func BenchmarkSetBlock(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+	idx := 0
+
+	f := &origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < 1000; i++ {
+		encoder.Write(f)
+	}
+
+	buf := encoder.Bytes()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		SetBlock(engine, "testing", &id, idx, buf)
+	}
+}
+
+func BenchmarkGetBlock(b *testing.B) {
+	engine, _ := origins.Init("memory", nil)
+
+	id := uuid.NewV4()
+	idx := 0
+
+	f := &origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < 1000; i++ {
+		encoder.Write(f)
+	}
+
+	SetBlock(engine, "testing", &id, idx, encoder.Bytes())
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		GetBlock(engine, "testing", &id, idx)
+	}
+}

--- a/dal/marshal.go
+++ b/dal/marshal.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/chop-dbhi/origins"
 	"github.com/chop-dbhi/origins/chrono"
@@ -13,21 +14,23 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// A slice of facts use length-prefix framing to delimit facts.
+// A slice of facts use length-prefix framing to delimit facts. The prefix is
+// a fixed size which requires the fact itself to not exceed the number of
+// bytes the prefix can encode.
+//
+//     [prefix] | [data] | [prefix] | [data] | ...
+//
 // See http://eli.thegreenplace.net/2011/08/02/length-prefix-framing-for-protocol-buffers
+// for additional information.
 const (
-	// Size in bytes of the number of facts that can be encoded.
-	frameHeaderSize = 2
+	// Size of the fact prefix for length-prefixing.
+	factPrefixSize = 4
 
-	// Size of the fact header for framing.
-	frameFactHeaderSize = 2
-
-	// Maximum fact size in bytes. The size is encoded and used as the boundary
-	// for length-prefix framing.
-	maxFactSize = 1 << 16
+	// Maximum fact size in bytes. This is imposed due to the length-prefixing
+	maxFactSize uint64 = 1 << (8 * factPrefixSize)
 )
 
-// encodeUUID encodes a UUID value into bytes..
+// encodeUUID encodes a UUID value into bytes.
 func encodeUUID(u *uuid.UUID) []byte {
 	if u == nil {
 		return nil
@@ -105,8 +108,8 @@ func unmarshalSegment(b []byte, s *Segment) error {
 	return nil
 }
 
-func marshalFact(f *origins.Fact) ([]byte, error) {
-	m := ProtoFact{}
+func marshalFact(m *ProtoFact, f *origins.Fact) ([]byte, error) {
+	m.Reset()
 
 	m.EntityDomain = proto.String(f.Entity.Domain)
 	m.Entity = proto.String(f.Entity.Name)
@@ -128,16 +131,16 @@ func marshalFact(f *origins.Fact) ([]byte, error) {
 		panic("fact: invalid op")
 	}
 
-	return proto.Marshal(&m)
+	return proto.Marshal(m)
 }
 
 // unmarshalFact decodes a fact from it's binary representation. The domain and
 // transaction ID are passed in since they are not encoded with the fact itself.
 // This is because facts are stored relative to a domain and a transaction.
-func unmarshalFact(b []byte, d string, t uint64, f *origins.Fact) error {
-	m := ProtoFact{}
+func unmarshalFact(m *ProtoFact, b []byte, d string, t uint64, f *origins.Fact) error {
+	m.Reset()
 
-	if err := proto.Unmarshal(b, &m); err != nil {
+	if err := proto.Unmarshal(b, m); err != nil {
 		return err
 	}
 
@@ -170,108 +173,6 @@ func unmarshalFact(b []byte, d string, t uint64, f *origins.Fact) error {
 	return nil
 }
 
-// Marshal encodes facts into it's binary representation.
-func marshalBlock(fs origins.Facts) ([]byte, error) {
-	var (
-		err error
-
-		// Fact buffer
-		fb []byte
-
-		// Size of the fact in bytes.
-		size int
-
-		// 2 byte length prefix per fact.
-		header = make([]byte, frameHeaderSize, frameHeaderSize)
-
-		// The full segment of bytes.
-		buf []byte
-	)
-
-	// Marshal each individual fact.
-	for _, f := range fs {
-		fb, err = marshalFact(f)
-
-		if err != nil {
-			return nil, err
-		}
-
-		size = len(fb)
-
-		if size > maxFactSize {
-			err = errors.New(fmt.Sprintf("fact: size %d exceeds maximum allowed %d", size, maxFactSize))
-			logrus.Error(err)
-			return nil, err
-		}
-
-		// Encode the size of the fact in the header of the fact.
-		binary.PutUvarint(header, uint64(size))
-
-		// Append the header, then the fact
-		buf = append(buf, header...)
-		buf = append(buf, fb...)
-	}
-
-	return buf, nil
-}
-
-// unmarshalBlock decodes a block of facts from it's binary representation.
-func unmarshalBlock(block []byte, d string, t uint64) (origins.Facts, error) {
-	var (
-		n       int
-		err     error
-		size    uint64
-		errcode int
-		fact    *origins.Fact
-	)
-
-	// Initialize a buffer of facts.
-	facts := origins.NewBuffer(nil)
-
-	// Initialize one buffer with the maximum fact size. A slice of the correct
-	// size will be passed into Read to get the expected size.
-	buf := make([]byte, maxFactSize)
-
-	// Wrap in buffer to make it easier to read.
-	reader := bytes.NewBuffer(block)
-
-	for {
-		n, err = reader.Read(buf[:frameFactHeaderSize])
-
-		// No more bytes.
-		if n == 0 {
-			break
-		}
-
-		if n != frameFactHeaderSize {
-			logrus.Panicf("unmarshal: fact expected %d bytes, got %d", frameFactHeaderSize, n)
-		}
-
-		// Decode the size of the fact.
-		if size, errcode = binary.Uvarint(buf[:frameFactHeaderSize]); errcode <= 0 {
-			logrus.Panic("unmarshal: could not decode fact size")
-		}
-
-		// Read the next bytes for the fact itself.
-		n, err = reader.Read(buf[:size])
-
-		if uint64(n) != size {
-			logrus.Panicf("unmarshal: fact expected to read %d bytes, got %d", size, n)
-		}
-
-		fact = &origins.Fact{}
-
-		if err = unmarshalFact(buf[:size], d, t, fact); err != nil {
-			return nil, err
-		}
-
-		// Add it to the buffer.
-		facts.Append(fact)
-	}
-
-	return facts.Facts(), nil
-}
-
 func marshalTx(tx *Transaction) ([]byte, error) {
 	m := ProtoTransaction{
 		ID:        proto.Uint64(tx.ID),
@@ -302,4 +203,178 @@ func unmarshalTx(b []byte, tx *Transaction) error {
 	}
 
 	return nil
+}
+
+// BlockEncoder encodes facts into a buffer.
+type BlockEncoder struct {
+	Count int
+
+	// Shared buffer for encoding the fact prefix.
+	prefix []byte
+
+	// Shared protobuf type for encoding the fact.
+	proto *ProtoFact
+
+	// Buffer of bytes containing the encoded facts.
+	block *bytes.Buffer
+}
+
+// Write encodes a fact and writes to the block.
+func (e *BlockEncoder) Write(f *origins.Fact) error {
+	data, err := marshalFact(e.proto, f)
+
+	if err != nil {
+		return err
+	}
+
+	// Size in bytes of the fact.
+	size := uint64(len(data))
+
+	if size > maxFactSize {
+		err = errors.New(fmt.Sprintf("fact: size %d exceeds maximum allowed %d", size, maxFactSize))
+		return err
+	}
+
+	// Encode the size of the fact in the prefix.
+	binary.PutUvarint(e.prefix, size)
+
+	// Write the data to the buffer..
+	e.block.Write(e.prefix)
+	e.block.Write(data)
+
+	e.Count++
+
+	return nil
+}
+
+// Bytes returns the unread slice of encoded bytes.
+func (e *BlockEncoder) Bytes() []byte {
+	return e.block.Bytes()
+}
+
+// Reset resets the internal buffer and sets the count to zero.
+func (e *BlockEncoder) Reset() {
+	e.Count = 0
+	e.block.Reset()
+}
+
+func NewBlockEncoder() *BlockEncoder {
+	return &BlockEncoder{
+		prefix: make([]byte, factPrefixSize, factPrefixSize),
+		block:  bytes.NewBuffer(nil),
+		proto:  new(ProtoFact),
+	}
+}
+
+// BlockDecoder decodes bytes into facts.
+type BlockDecoder struct {
+	Domain      string
+	Transaction uint64
+	Count       int
+
+	// Shared buffer for encoding the fact prefix and data.
+	prefix []byte
+	data   []byte
+
+	// Shared protobuf type for encoding the fact.
+	proto *ProtoFact
+
+	// Buffer of bytes containing the encoded facts.
+	block *bytes.Buffer
+
+	err error
+}
+
+func (d *BlockDecoder) alloc(n int) []byte {
+	// Allocate larger buffer.
+	if len(d.data) < n {
+		d.data = make([]byte, n, n)
+	}
+
+	return d.data[:n]
+}
+
+func (d *BlockDecoder) Empty() bool {
+	return d.block.Len() == 0
+}
+
+func (d *BlockDecoder) Next() *origins.Fact {
+	if d.err != nil {
+		return nil
+	}
+
+	var (
+		n   int
+		err error
+	)
+
+	// Read the prefix.
+	if n, err = d.block.Read(d.prefix); err != nil {
+		d.err = err
+		return nil
+	}
+
+	// No more bytes.
+	if n == 0 {
+		return nil
+	}
+
+	// Ensure the full prefix was read.
+	if n != factPrefixSize {
+		d.err = io.ErrUnexpectedEOF
+		return nil
+	}
+
+	var (
+		size    uint64
+		errcode int
+	)
+
+	// Decode the size of the data.
+	if size, errcode = binary.Uvarint(d.prefix); errcode <= 0 {
+		logrus.Panic("decode: could not decode fact prefix")
+	}
+
+	// Allocate a buffer of the specified size.
+	buf := d.alloc(int(size))
+
+	// Read the next bytes for the fact itself.
+	if n, err = d.block.Read(buf); err != nil {
+		d.err = err
+		return nil
+	}
+
+	// Ensure the expected number of bytes were read.
+	if uint64(n) != size {
+		d.err = io.ErrUnexpectedEOF
+		return nil
+	}
+
+	// Decode the data into the fact.
+	fact := &origins.Fact{}
+
+	if err = unmarshalFact(d.proto, buf, d.Domain, d.Transaction, fact); err != nil {
+		d.err = err
+		return nil
+	}
+
+	return fact
+}
+
+func (d *BlockDecoder) Err() error {
+	if d.err == io.EOF {
+		return nil
+	}
+
+	return d.err
+}
+
+func NewBlockDecoder(block []byte, domain string, tx uint64) *BlockDecoder {
+	return &BlockDecoder{
+		Domain:      domain,
+		Transaction: tx,
+		prefix:      make([]byte, factPrefixSize, factPrefixSize),
+		block:       bytes.NewBuffer(block),
+		proto:       new(ProtoFact),
+	}
 }

--- a/dal/marshal_test.go
+++ b/dal/marshal_test.go
@@ -1,0 +1,295 @@
+package dal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chop-dbhi/origins"
+	"github.com/chop-dbhi/origins/chrono"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalFact(t *testing.T) {
+	f := origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	m := ProtoFact{}
+
+	b, err := marshalFact(&m, &f)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	f2 := origins.Fact{}
+
+	if err = unmarshalFact(&m, b, "testing", 5, &f2); err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, f.Operation, f2.Operation)
+	assert.Equal(t, f.Time, f2.Time)
+	assert.True(t, f.Entity.Is(f2.Entity))
+	assert.True(t, f.Value.Is(f2.Value))
+}
+
+func TestBlockEncoder(t *testing.T) {
+	f := origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < 5; i++ {
+		if err := encoder.Write(&f); err != nil {
+			t.Error(err)
+		}
+	}
+
+	if encoder.Count != 5 {
+		t.Error("expected 5, got %d", encoder.Count)
+	}
+}
+
+func TestBlockDecoder(t *testing.T) {
+	f := origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < 5; i++ {
+		encoder.Write(&f)
+	}
+
+	// Initialize decoder with encoded bytes.
+	decoder := NewBlockDecoder(encoder.Bytes(), "testing", 5)
+
+	var n int
+
+	for {
+		fact := decoder.Next()
+
+		if fact == nil {
+			break
+		}
+
+		n++
+	}
+
+	if err := decoder.Err(); err != nil {
+		t.Error(err)
+	}
+
+	if n != encoder.Count {
+		t.Error("expected 5, got %d", n)
+	}
+}
+
+func BenchmarkMarshalFact(b *testing.B) {
+	f := &origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	m := &ProtoFact{}
+
+	for i := 0; i < b.N; i++ {
+		marshalFact(m, f)
+	}
+}
+
+func BenchmarkUnmarshalFact(b *testing.B) {
+	f := &origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	f2 := &origins.Fact{}
+
+	m := &ProtoFact{}
+
+	bf, _ := marshalFact(m, f)
+
+	for i := 0; i < b.N; i++ {
+		unmarshalFact(m, bf, "testing", 5, f2)
+	}
+}
+
+func BenchmarkBlockEncoder(b *testing.B) {
+	f := origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < b.N; i++ {
+		encoder.Write(&f)
+	}
+}
+
+func BenchmarkBlockDecoder(b *testing.B) {
+	// Stop to do large initialization.
+	b.StopTimer()
+
+	f := &origins.Fact{
+		Domain: "testing",
+
+		Operation: origins.Assertion,
+
+		Transaction: 5,
+
+		Time: chrono.Norm(time.Now()),
+
+		Entity: &origins.Ident{
+			Domain: "testing",
+			Name:   "field",
+		},
+
+		Attribute: &origins.Ident{
+			Domain: "testing",
+			Name:   "dataType",
+		},
+
+		Value: &origins.Ident{
+			Name: "string",
+		},
+	}
+
+	encoder := NewBlockEncoder()
+
+	for i := 0; i < 2000000; i++ {
+		encoder.Write(f)
+	}
+
+	// Initialize decoder with encoded bytes.
+	decoder := NewBlockDecoder(encoder.Bytes(), "testing", 5)
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		if f = decoder.Next(); f == nil {
+			b.Error("decoder: ran out of facts")
+			break
+		}
+	}
+}

--- a/dal/methods.go
+++ b/dal/methods.go
@@ -3,7 +3,6 @@ package dal
 import (
 	"fmt"
 
-	"github.com/chop-dbhi/origins"
 	"github.com/chop-dbhi/origins/storage"
 	"github.com/satori/go.uuid"
 )
@@ -130,36 +129,16 @@ func DeleteSegment(e storage.Tx, domain string, id *uuid.UUID) error {
 // GetBlock returns a block from storage. The lookup requires the domain, ID of the segment
 // the block is contained in, the index of the block in the segment, and the transaction
 // that processed the segment.
-func GetBlock(e storage.Tx, domain string, id *uuid.UUID, idx int, tx uint64) (origins.Facts, error) {
-	var (
-		bytes []byte
-		err   error
-		key   string
-	)
+func GetBlock(e storage.Tx, domain string, id *uuid.UUID, idx int) ([]byte, error) {
+	var key string
 
 	key = fmt.Sprintf(blockKey, id, idx)
 
-	if bytes, err = e.Get(domain, key); err != nil {
-		return nil, err
-	}
-
-	if bytes == nil {
-		return nil, nil
-	}
-
-	return unmarshalBlock(bytes, domain, tx)
+	return e.Get(domain, key)
 }
 
-func SetBlock(e storage.Tx, domain string, id *uuid.UUID, idx int, block origins.Facts) (int, error) {
-	var (
-		bytes []byte
-		err   error
-		key   string
-	)
-
-	if bytes, err = marshalBlock(block); err != nil {
-		return 0, err
-	}
+func SetBlock(e storage.Tx, domain string, id *uuid.UUID, idx int, bytes []byte) (int, error) {
+	var key string
 
 	key = fmt.Sprintf(blockKey, id, idx)
 

--- a/transactor/pipeline.go
+++ b/transactor/pipeline.go
@@ -90,7 +90,7 @@ func (p *DomainPipeline) Init(tx *Transaction) error {
 }
 
 func (p *DomainPipeline) Receive(fact *origins.Fact) error {
-	return p.segment.Append(fact)
+	return p.segment.Write(fact)
 }
 
 func (p *DomainPipeline) Abort(tx storage.Tx) error {
@@ -104,7 +104,7 @@ func (p *DomainPipeline) Commit(tx storage.Tx) error {
 	)
 
 	// Write the remaining block of the segment.
-	if err = p.segment.Write(tx); err != nil {
+	if err = p.segment.Commit(tx); err != nil {
 		return err
 	}
 

--- a/view/log_test.go
+++ b/view/log_test.go
@@ -199,14 +199,15 @@ func TestLogExcludeDuplicates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if num != n*m {
 		t.Errorf("expected %d total facts, got %d", n*m, num)
 	}
 
 	// Now check that Next() works on the deduplicated stream,
 	// and verify the number of unique facts.
-
 	iter := Deduplicate(log.Now())
+
 	if err := iter.Err(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This change introduces a BlockEncoder and BlockDecoder which
incrementally encodes and decodes facts. The previous behavior was to
handle the whole block of facts at once which is more of a “stop-the-world”
approach.

Although the overall performance may not improved, the flow is much more
clear and incremental. In addition, this stream based composition is
necessary for refactoring the processing into a concurrent model.

Additional refactoring has been made to standardize on the Writer and
Flusher interfaces rather than using alternate methods (Append).

Increase maximum fact size has been increased to 2^32 bytes which
requires a 4-byte encoding prefix. Fix #146

Signed-off-by: Byron Ruth <b@devel.io>