### PR TITLE
Bind to separate viper keys for storage options

### DIFF
--- a/cmd/origins/domains.go
+++ b/cmd/origins/domains.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"sort"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/chop-dbhi/origins"
 	"github.com/chop-dbhi/origins/view"
-	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +16,7 @@ var domainsCmd = &cobra.Command{
 	Short: "Outputs a list of domains.",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		engine := initStorage()
+		engine := initStorage("domains")
 
 		log, err := view.OpenLog(engine, origins.DomainsDomain, "commit")
 
@@ -41,5 +41,5 @@ var domainsCmd = &cobra.Command{
 func init() {
 	flags := domainsCmd.Flags()
 
-	addStorageFlags(flags)
+	addStorageFlags(flags, "domains")
 }

--- a/cmd/origins/http.go
+++ b/cmd/origins/http.go
@@ -23,14 +23,14 @@ var httpCmd = &cobra.Command{
 
 		debug := logrus.GetLevel() == logrus.DebugLevel
 
-		http.Serve(initStorage(), host, port, debug)
+		http.Serve(initStorage("http"), host, port, debug)
 	},
 }
 
 func init() {
 	flags := httpCmd.Flags()
 
-	addStorageFlags(flags)
+	addStorageFlags(flags, "http")
 
 	flags.String("host", "", "The host the HTTP service will listen on.")
 	flags.Int("port", 49110, "The port the HTTP will bind to.")

--- a/cmd/origins/log.go
+++ b/cmd/origins/log.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/chop-dbhi/origins"
 	"github.com/chop-dbhi/origins/chrono"
 	"github.com/chop-dbhi/origins/storage"
 	"github.com/chop-dbhi/origins/view"
-	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -95,7 +95,7 @@ var logCmd = &cobra.Command{
 		since, _ = chrono.Parse(viper.GetString("log_since"))
 		asof, _ = chrono.Parse(viper.GetString("log_asof"))
 
-		engine := initStorage()
+		engine := initStorage("log")
 
 		if file == "" {
 			w = os.Stdout
@@ -135,7 +135,7 @@ var logCmd = &cobra.Command{
 func init() {
 	flags := logCmd.Flags()
 
-	addStorageFlags(flags)
+	addStorageFlags(flags, "log")
 
 	flags.String("asof", "", "Defines the upper time boundary of facts to be read.")
 	flags.String("since", "", "Defines the lower time boundary of facts to be read. ")

--- a/cmd/origins/storage.go
+++ b/cmd/origins/storage.go
@@ -3,26 +3,26 @@ package main
 import (
 	"path/filepath"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/chop-dbhi/origins"
 	"github.com/chop-dbhi/origins/storage"
-	"github.com/Sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
 // Augments a command's flag set with storage-related flags.
-func addStorageFlags(flags *pflag.FlagSet) {
+func addStorageFlags(flags *pflag.FlagSet, prefix string) {
 	flags.String("storage", "memory", "Storage backend. Choices are: boltdb and memory.")
 	flags.String("path", "", "Path to a file or directory filesystem-based storage backends.")
 
-	viper.BindPFlag("storage", flags.Lookup("storage"))
-	viper.BindPFlag("path", flags.Lookup("path"))
+	viper.BindPFlag(prefix+"_storage", flags.Lookup("storage"))
+	viper.BindPFlag(prefix+"_path", flags.Lookup("path"))
 }
 
 // Commands can call this if it requires use of the store.
-func initStorage() storage.Engine {
+func initStorage(prefix string) storage.Engine {
 	// Name of the storage engine.
-	name := viper.GetString("storage")
+	name := viper.GetString(prefix + "_storage")
 
 	// Directory of the config file. Ensure the storage engine
 	// path is resolved relative to the config file.
@@ -30,7 +30,7 @@ func initStorage() storage.Engine {
 	dir := filepath.Dir(cf)
 
 	// Get path relative to config file.
-	path := filepath.Join(dir, viper.GetString("path"))
+	path := filepath.Join(dir, viper.GetString(prefix+"_path"))
 
 	// Supported options.
 	opts := storage.Options{

--- a/cmd/origins/transact.go
+++ b/cmd/origins/transact.go
@@ -8,9 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/chop-dbhi/origins"
 	"github.com/chop-dbhi/origins/transactor"
-	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -55,7 +55,7 @@ var transactCmd = &cobra.Command{
 	Long: `transact reads facts from stdin or from one or more paths specified paths.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		engine := initStorage()
+		engine := initStorage("transact")
 
 		format := viper.GetString("transact_format")
 		compression := viper.GetString("transact_compression")
@@ -135,7 +135,7 @@ var transactCmd = &cobra.Command{
 func init() {
 	flags := transactCmd.Flags()
 
-	addStorageFlags(flags)
+	addStorageFlags(flags, "transact")
 
 	flags.String("format", "", "Format of the stream of facts. Choices are: csv")
 	flags.String("compression", "", "Compression method of the stream of facts. Choices are: bzip2, gzip")


### PR DESCRIPTION
If the same flag is associated with several cobra commands, the flag
should be bound to a different viper tag for each command.

Otherwise only the command that got initialized last gets to keep the
binding, and the other commands get stuck with the default value for
the flag.

In our case, init() gets called last for the transact command, so
transact was picking up the correct value of the --storage flag, and
other commands, like http and domains, were getting the default
storage==“memory” no matter what value was being passed in.