### PR TITLE
Bind command flags in run phase

### DIFF
--- a/cmd/origins/domains.go
+++ b/cmd/origins/domains.go
@@ -16,7 +16,9 @@ var domainsCmd = &cobra.Command{
 	Short: "Outputs a list of domains.",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		engine := initStorage("domains")
+		bindStorageFlags(cmd.Flags())
+
+		engine := initStorage()
 
 		log, err := view.OpenLog(engine, origins.DomainsDomain, "commit")
 
@@ -40,6 +42,5 @@ var domainsCmd = &cobra.Command{
 
 func init() {
 	flags := domainsCmd.Flags()
-
-	addStorageFlags(flags, "domains")
+	addStorageFlags(flags)
 }

--- a/cmd/origins/http.go
+++ b/cmd/origins/http.go
@@ -16,21 +16,21 @@ var httpCmd = &cobra.Command{
 	Long: "Runs a process exposing an HTTP interface.",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		var (
-			host = viper.GetString("http_host")
-			port = viper.GetInt("http_port")
-		)
+		bindStorageFlags(cmd.Flags())
 
+		engine := initStorage()
+		host := viper.GetString("http_host")
+		port := viper.GetInt("http_port")
 		debug := logrus.GetLevel() == logrus.DebugLevel
 
-		http.Serve(initStorage("http"), host, port, debug)
+		http.Serve(engine, host, port, debug)
 	},
 }
 
 func init() {
 	flags := httpCmd.Flags()
 
-	addStorageFlags(flags, "http")
+	addStorageFlags(flags)
 
 	flags.String("host", "", "The host the HTTP service will listen on.")
 	flags.Int("port", 49110, "The port the HTTP will bind to.")

--- a/cmd/origins/log.go
+++ b/cmd/origins/log.go
@@ -77,6 +77,8 @@ var logCmd = &cobra.Command{
 	Short: "Output the log for one or more domains.",
 
 	Run: func(cmd *cobra.Command, args []string) {
+		bindStorageFlags(cmd.Flags())
+
 		if len(args) == 0 {
 			cmd.Usage()
 			os.Exit(1)
@@ -95,7 +97,7 @@ var logCmd = &cobra.Command{
 		since, _ = chrono.Parse(viper.GetString("log_since"))
 		asof, _ = chrono.Parse(viper.GetString("log_asof"))
 
-		engine := initStorage("log")
+		engine := initStorage()
 
 		if file == "" {
 			w = os.Stdout
@@ -135,7 +137,7 @@ var logCmd = &cobra.Command{
 func init() {
 	flags := logCmd.Flags()
 
-	addStorageFlags(flags, "log")
+	addStorageFlags(flags)
 
 	flags.String("asof", "", "Defines the upper time boundary of facts to be read.")
 	flags.String("since", "", "Defines the lower time boundary of facts to be read. ")

--- a/cmd/origins/storage.go
+++ b/cmd/origins/storage.go
@@ -10,27 +10,29 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Augments a command's flag set with storage-related flags.
-func addStorageFlags(flags *pflag.FlagSet, prefix string) {
+// Adds storage-related flags to a command's flag set.
+func addStorageFlags(flags *pflag.FlagSet) {
 	flags.String("storage", "memory", "Storage backend. Choices are: boltdb and memory.")
 	flags.String("path", "", "Path to a file or directory filesystem-based storage backends.")
+}
 
-	viper.BindPFlag(prefix+"_storage", flags.Lookup("storage"))
-	viper.BindPFlag(prefix+"_path", flags.Lookup("path"))
+// Binds the storage flags to the viper object. This should be called within
+// the command's Run method.
+func bindStorageFlags(flags *pflag.FlagSet) {
+	viper.BindPFlag("storage", flags.Lookup("storage"))
+	viper.BindPFlag("path", flags.Lookup("path"))
 }
 
 // Commands can call this if it requires use of the store.
-func initStorage(prefix string) storage.Engine {
+func initStorage() storage.Engine {
 	// Name of the storage engine.
-	name := viper.GetString(prefix + "_storage")
+	name := viper.GetString("storage")
+	path := viper.GetString("path")
 
 	// Directory of the config file. Ensure the storage engine
 	// path is resolved relative to the config file.
-	cf := viper.ConfigFileUsed()
-	dir := filepath.Dir(cf)
-
-	// Get path relative to config file.
-	path := filepath.Join(dir, viper.GetString(prefix+"_path"))
+	dir := filepath.Dir(viper.ConfigFileUsed())
+	path = filepath.Join(dir, path)
 
 	// Supported options.
 	opts := storage.Options{

--- a/cmd/origins/transact.go
+++ b/cmd/origins/transact.go
@@ -55,7 +55,9 @@ var transactCmd = &cobra.Command{
 	Long: `transact reads facts from stdin or from one or more paths specified paths.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		engine := initStorage("transact")
+		bindStorageFlags(cmd.Flags())
+
+		engine := initStorage()
 
 		format := viper.GetString("transact_format")
 		compression := viper.GetString("transact_compression")
@@ -135,7 +137,7 @@ var transactCmd = &cobra.Command{
 func init() {
 	flags := transactCmd.Flags()
 
-	addStorageFlags(flags, "transact")
+	addStorageFlags(flags)
 
 	flags.String("format", "", "Format of the stream of facts. Choices are: csv")
 	flags.String("compression", "", "Compression method of the stream of facts. Choices are: bzip2, gzip")


### PR DESCRIPTION
This fixes the problem of each subcommand overriding the flag that is
bound to a shared viper setting without needing to namespace them. Adding
a namespace prevented using a common name in configuration files or
environment variables.

Binding to the target flag is now deferred until the command’s Run
method is called which ensures it read from the correct flag set.

Fix #167

Signed-off-by: Byron Ruth <b@devel.io>